### PR TITLE
Add MySQL SQL mode getter/setter

### DIFF
--- a/lib/Doctrine/Connection/Mysql.php
+++ b/lib/Doctrine/Connection/Mysql.php
@@ -134,6 +134,7 @@ class Doctrine_Connection_Mysql extends Doctrine_Connection_Common
     {
         return $this->fetchOne('SELECT @@sql_mode');
     }
+
     /**
      * Set the SQL mode on the current connection
      *
@@ -145,6 +146,41 @@ class Doctrine_Connection_Mysql extends Doctrine_Connection_Common
     {
         $query = 'SET sql_mode = ' . $this->quote($sqlmode);
         $this->exec($query);
+    }
+
+    /**
+     * Return version information about the server
+     *
+     * @param bool $native    determines if the raw version string should be returned
+     * @return array|string     an array or string with version information
+     */
+    public function getServerVersion($native = false)
+    {
+        $query = 'SELECT VERSION()';
+        $serverInfo = $this->fetchOne($query);
+        if ( ! $native) {
+            $tmp = explode('.', $serverInfo, 3);
+            if (empty($tmp[2]) && isset($tmp[1])
+                && preg_match('/(\d+)(.*)/', $tmp[1], $tmp2)
+            ) {
+                $serverInfo = array(
+                    'major' => $tmp[0],
+                    'minor' => $tmp2[1],
+                    'patch' => null,
+                    'extra' => $tmp2[2],
+                    'native' => $serverInfo,
+                );
+            } else {
+                $serverInfo = array(
+                    'major' => isset($tmp[0]) ? $tmp[0] : null,
+                    'minor' => isset($tmp[1]) ? $tmp[1] : null,
+                    'patch' => isset($tmp[2]) ? $tmp[2] : null,
+                    'extra' => null,
+                    'native' => $serverInfo,
+                );
+            }
+        }
+        return $serverInfo;
     }
 
     /**

--- a/lib/Doctrine/Connection/Mysql.php
+++ b/lib/Doctrine/Connection/Mysql.php
@@ -128,6 +128,26 @@ class Doctrine_Connection_Mysql extends Doctrine_Connection_Common
     }
 
     /**
+     * Get the SQL mode on the current connection
+     */
+    public function getSqlMode()
+    {
+        return $this->fetchOne('SELECT @@sql_mode');
+    }
+    /**
+     * Set the SQL mode on the current connection
+     *
+     * @param string $sqlmode   SQL mode
+     *
+     * @link http://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_sql-mode
+     */
+    public function setSqlMode($sqlmode)
+    {
+        $query = 'SET sql_mode = ' . $this->quote($sqlmode);
+        $this->exec($query);
+    }
+
+    /**
      * Execute a SQL REPLACE query. A REPLACE query is identical to a INSERT
      * query, except that if there is already a row in the table with the same
      * key field values, the REPLACE query just updates its values instead of


### PR DESCRIPTION
This patch add getter/setter for MySQL SQL mode and a new method to get MySQL server version in a structured way 

MySQL 5.7 GA release (5.7.9) change the default SQL mode from NO_ENGINE_SUBSTITUTION to ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION breaking some legacy applications: thanks to these methods sql_mode can be changed on the fly with Doctrine