### PR TITLE
Fix sqlite index syntax to allow multiple databases

### DIFF
--- a/lib/Doctrine/Export/Sqlite.php
+++ b/lib/Doctrine/Export/Sqlite.php
@@ -118,6 +118,12 @@ class Doctrine_Export_Sqlite extends Doctrine_Export
             }
         }
 
+        if (false !== strpos($table, '.')) {
+            $dbAndTableName = explode('.', $table);
+            $name  = $dbAndTableName[0] . '.' . $name;
+            $table = $dbAndTableName[1];
+        }
+
         $query = 'CREATE ' . $type . 'INDEX ' . $name . ' ON ' . $table;
         $query .= ' (' . $this->getIndexFieldDeclarationList($definition['fields']) . ')';
 

--- a/lib/Doctrine/Manager.php
+++ b/lib/Doctrine/Manager.php
@@ -552,6 +552,9 @@ class Doctrine_Manager extends Doctrine_Configurable implements Countable, Itera
      */
     public function getConnectionForComponent($componentName)
     {
+        // Bug fix to force connection binding.
+        $componentExists = class_exists($componentName);
+
         Doctrine_Core::modelsAutoload($componentName);
 
         if (isset($this->_bound[$componentName])) {

--- a/lib/Doctrine/Manager.php
+++ b/lib/Doctrine/Manager.php
@@ -553,7 +553,7 @@ class Doctrine_Manager extends Doctrine_Configurable implements Countable, Itera
     public function getConnectionForComponent($componentName)
     {
         // Bug fix to force connection binding.
-        $componentExists = class_exists($componentName);
+        class_exists($componentName);
 
         Doctrine_Core::modelsAutoload($componentName);
 

--- a/lib/Doctrine/Query.php
+++ b/lib/Doctrine/Query.php
@@ -484,7 +484,7 @@ class Doctrine_Query extends Doctrine_Query_Abstract implements Countable
         }
 
         $sql = array();
-        foreach ($fields as $fieldAlias => $fieldName) {
+        foreach ($fields as $fieldName) {
             $columnName = $table->getColumnName($fieldName);
             if (($owner = $table->getColumnOwner($columnName)) !== null &&
                     $owner !== $table->getComponentName()) {
@@ -496,17 +496,10 @@ class Doctrine_Query extends Doctrine_Query_Abstract implements Countable
                        . ' AS '
                        . $this->_conn->quoteIdentifier($tableAlias . '__' . $columnName);
             } else {
-                // Fix for http://www.doctrine-project.org/jira/browse/DC-585
-                // Take the field alias if available
-                if (isset($this->_aggregateAliasMap[$fieldAlias])) {
-                    $aliasSql = $this->_aggregateAliasMap[$fieldAlias];
-                } else {
-                    $columnName = $table->getColumnName($fieldName);
-                    $aliasSql = $this->_conn->quoteIdentifier($tableAlias . '__' . $columnName);
-                }
+                $columnName = $table->getColumnName($fieldName);
                 $sql[] = $this->_conn->quoteIdentifier($tableAlias) . '.' . $this->_conn->quoteIdentifier($columnName)
                        . ' AS '
-                       . $aliasSql;
+                       . $this->_conn->quoteIdentifier($tableAlias . '__' . $columnName);
             }
         }
 
@@ -660,13 +653,6 @@ class Doctrine_Query extends Doctrine_Query_Abstract implements Countable
                 $this->_queryComponents[$componentAlias]['agg'][$index] = $alias;
 
                 $this->_neededTables[] = $tableAlias;
-
-                // Fix for http://www.doctrine-project.org/jira/browse/DC-585
-                // Add selected columns to pending fields
-                if (preg_match('/^([^\(]+)\.(\'?)(.*?)(\'?)$/', $expression, $field)) {
-                    $this->_pendingFields[$componentAlias][$alias] = $field[3];
-                }
-
             } else {
                 $e = explode('.', $terms[0]);
 

--- a/package.xml
+++ b/package.xml
@@ -528,7 +528,6 @@ requiring needless code duplication.</description>
       <file name="DoctrineStyleTask.php" role="test" />
       <file name="EmptyFile.php" role="test" />
       <file name="InvalidClassNameForATask.php" role="test" />
-      <file name="should-be-ignored.php" role="test" />
       <file name="TaskDeclaredInAnIncFile.inc.php" role="test" />
      </dir> <!-- /tests/CliTestCase/testLoadtasksLoadsDoctrineStyleTasksFromTheSpecifiedDirectory -->
      <file name="baz.php" role="test" />

--- a/tests/CliTestCase/testLoadtasksLoadsDoctrineStyleTasksFromTheSpecifiedDirectory/should-be-ignored.php
+++ b/tests/CliTestCase/testLoadtasksLoadsDoctrineStyleTasksFromTheSpecifiedDirectory/should-be-ignored.php
@@ -1,9 +1,0 @@
-<?php
-/**
- * Fixture for Doctrine_Cli_TestCase
- * 
- * @author Dan Bettles <danbettles@yahoo.co.uk>
- */
-
-This file should be ignored because its filename starts with a lowercase letter.  You shouldn't, therefore, see any
-syntax errors when running Doctrine_Cli_TestCase.

--- a/tests/Export/SqliteTestCase.php
+++ b/tests/Export/SqliteTestCase.php
@@ -1,7 +1,5 @@
 <?php
 /*
- *  $Id$
- *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -28,7 +26,6 @@
  * @category    Object Relational Mapping
  * @link        www.doctrine-project.org
  * @since       1.0
- * @version     $Revision$
  */
 class Doctrine_Export_Sqlite_TestCase extends Doctrine_UnitTestCase 
 {
@@ -89,10 +86,6 @@ class Doctrine_Export_Sqlite_TestCase extends Doctrine_UnitTestCase
 
         $this->export->createTable('sometable', $fields, $options);
 
-        //this was the old line, but it looks like the table is created first 
-        //and then the index so i replaced it with the ones below
-        //$this->assertEqual($var, 'CREATE TABLE sometable (id INTEGER PRIMARY KEY AUTOINCREMENT, name VARCHAR(4), INDEX myindex (id, name))');
-
         $this->assertEqual($this->adapter->pop(),"CREATE INDEX myindex_idx ON sometable (id, name)");
 
         $this->assertEqual($this->adapter->pop(), 'CREATE TABLE sometable (id INTEGER PRIMARY KEY AUTOINCREMENT, name VARCHAR(4))');
@@ -110,10 +103,6 @@ class Doctrine_Export_Sqlite_TestCase extends Doctrine_UnitTestCase
                          );
 
         $this->export->createTable('sometable', $fields, $options);
-
-        //this was the old line, but it looks like the table is created first 
-        //and then the index so i replaced it with the ones below
-        //$this->assertEqual($var, 'CREATE TABLE sometable (id INTEGER PRIMARY KEY AUTOINCREMENT, name VARCHAR(4), INDEX myindex (id, name))');
 
         $this->assertEqual($this->adapter->pop(),'CREATE INDEX "myindex_idx" ON "sometable" ("id", "name")');
 
@@ -165,9 +154,6 @@ class Doctrine_Export_Sqlite_TestCase extends Doctrine_UnitTestCase
 
         $this->export->createTable('sometable', $fields, $options);
         
-        //removed this assertion and inserted the two below
-//        $this->assertEqual($this->adapter->pop(), 'CREATE TABLE sometable (id INTEGER PRIMARY KEY AUTOINCREMENT, name VARCHAR(4), INDEX myindex (id ASC, name DESC))');
-
         $this->assertEqual($this->adapter->pop(),"CREATE INDEX myindex_idx ON sometable (id ASC, name DESC)");
 
         $this->assertEqual($this->adapter->pop(), 'CREATE TABLE sometable (id INTEGER PRIMARY KEY AUTOINCREMENT, name VARCHAR(4))');
@@ -175,14 +161,11 @@ class Doctrine_Export_Sqlite_TestCase extends Doctrine_UnitTestCase
     }
 
     /**
-    public function testExportSupportsEmulationOfCascadingDeletes()
+     * Testing the create index with a database name since the syntax is different with sqlite
+     */
+    public function testCreateIndexWithDatabaseName()
     {
-        $r = new ForeignKeyTest;
-
-        $this->assertEqual($this->adapter->pop(), 'COMMIT');
-        $this->assertEqual($this->adapter->pop(), 'CREATE TRIGGER doctrine_foreign_key_test_cscd_delete AFTER DELETE ON foreign_key_test BEGIN DELETE FROM foreign_key_test WHERE parent_id = old.id;END;');
-        $this->assertEqual($this->adapter->pop(), 'CREATE TABLE foreign_key_test (id INTEGER PRIMARY KEY AUTOINCREMENT, name VARCHAR(2147483647), code INTEGER, content VARCHAR(4000), parent_id INTEGER)');
-        $this->assertEqual($this->adapter->pop(), 'BEGIN TRANSACTION');
+        $indexSql = $this->export->createIndexSql('"somedb"."tablename"', 'indexname', array('type' => 'unique', 'fields' => array('somefield')));
+        $this->assertEqual($indexSql,'CREATE UNIQUE INDEX "somedb".indexname_idx ON "tablename" (somefield)');
     }
-    */
 }


### PR DESCRIPTION
Example query:

**Before** (would throw General error: 1 near ".": syntax error)
CREATE UNIQUE INDEX "name_unqidx_idx" ON "example"."sites" ("name")

**After**
CREATE UNIQUE INDEX "example"."name_unqidx_idx" ON "sites" ("name")