### PR TITLE
Cannot declare self-referencing constant 'Doctrine_Query::STATE_CLEAN'

### DIFF
--- a/lib/Doctrine/Query/Abstract.php
+++ b/lib/Doctrine/Query/Abstract.php
@@ -97,7 +97,7 @@ abstract class Doctrine_Query_Abstract
     /**
      * @var integer $_state   The current state of this query.
      */
-    protected $_state = Doctrine_Query::STATE_CLEAN;
+    protected $_state = Doctrine_Query_Abstract::STATE_CLEAN;
 
     /**
      * @var array $_params  The parameters of this query.


### PR DESCRIPTION
You will trigger a : Fatal error: Uncaught Error: Cannot declare self-referencing constant 'Doctrine_Query::STATE_CLEAN'

If you try to call in this order :
$q = new Doctrine_RawSql($conn);
$q = new Doctrine_Query($conn);

This is due to the fact that Doctrine_RawSql extends Doctrine_Query_Abstract, so PhP had to declare both of them.

But Doctrine_Query_Abstract also require Doctrine_Query to get the "default" $_state , which is Doctrine_Query::STATE_CLEAN.

And then when you instantiate a new Doctrine_Query() which also extend Doctrine_Query_Abstract(), Php try to declare again Doctrine_Query, which constant has already been declared during the previous declaration of Doctrine_RawSql > "extends" > Doctrine_Query_Abstract > "needs" > Doctrine_Query

Solution : call the Abstract class directly

Tested and reproduced on php7.0 and Php7.1
Php5.6 and bellow are not impacted (not tested on php 5.7)
Bug fix tested on php7.0 7.1 5.6 and 5.5