### PR TITLE
Fix access to undefined index on certain conditions

### DIFF
--- a/lib/Doctrine/Import/Builder.php
+++ b/lib/Doctrine/Import/Builder.php
@@ -782,7 +782,7 @@ class Doctrine_Import_Builder extends Doctrine_Builder
             if (isset($definition['relations']) && ! empty($definition['relations'])) {
                 foreach ($definition['relations'] as $relation) {
                     $type = (isset($relation['type']) && $relation['type'] == Doctrine_Relation::MANY) ? 'Doctrine_Collection' : $this->_classPrefix . $relation['class'];
-                    if ($relation["type"] == Doctrine_Relation::ONE) {
+                    if (!isset($relation['type']) || $relation["type"] == Doctrine_Relation::ONE) {
                         $properties[] = array($relation['class'], $relation['alias'], "");
                         $getters[] = array($relation['class'], $relation['alias'], "");
                         $setters[] = array($definition['topLevelClassName'], $relation['alias'], $relation['class'], "");


### PR DESCRIPTION
Given certain parameters it was accessing `$relation['type']` without checking the `type` key existed (which does a line above).