### PR TITLE
fix warning in php 7.3

### DIFF
--- a/lib/Doctrine/Query/Tokenizer.php
+++ b/lib/Doctrine/Query/Tokenizer.php
@@ -93,7 +93,7 @@ class Doctrine_Query_Tokenizer
                 break;
 
                 case 'by':
-                    continue;
+                break;
 
                 default:
                     if ( ! isset($p)) {


### PR DESCRIPTION
"continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?