### PR TITLE
Hotfix/custom alias adds column twice and crashes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,14 +6,22 @@
     "homepage": "http://www.doctrine-project.org",
     "license": "LGPL-2.1-or-later",
     "authors": [
-        {"name": "Konsta Vesterinen", "email": "kvesteri@cc.hut.fi"},
-        {"name": "Jonathan Wage", "email": "jonwage@gmail.com"}
+        {
+            "name": "Konsta Vesterinen",
+            "email": "kvesteri@cc.hut.fi"
+        },
+        {
+            "name": "Jonathan Wage",
+            "email": "jonwage@gmail.com"
+        }
     ],
     "require": {
         "php": ">=5.2.3",
         "ext-pdo": "*"
     },
     "autoload": {
-        "psr-0": { "Doctrine_": "lib/" }
+        "psr-0": {
+            "Doctrine_": "lib/"
+        }
     }
 }

--- a/lib/Doctrine/Query.php
+++ b/lib/Doctrine/Query.php
@@ -662,11 +662,13 @@ class Doctrine_Query extends Doctrine_Query_Abstract implements Countable
 
                 $this->_neededTables[] = $tableAlias;
 
+                // This causes the column to be added twice, if the user defines a custom alias
+                // in the select statement.
                 // Fix for http://www.doctrine-project.org/jira/browse/DC-585
                 // Add selected columns to pending fields
-                if (preg_match('/^([^\(]+)\.(\'?)(.*?)(\'?)$/', $expression, $field)) {
+                /*if (preg_match('/^([^\(]+)\.(\'?)(.*?)(\'?)$/', $expression, $field)) {
                     $this->_pendingFields[$componentAlias][$alias] = $field[3];
-                }
+                }*/
 
             } else {
                 $e = explode('.', $terms[0]);


### PR DESCRIPTION
The commented out fix, shown in this pull request, breaks the usage of custom aliases in the query, because it will be added twice to the query. First to the sqlParts-List here (https://github.com/vemaeg/doctrine1/blob/502b8cce687bf57b3f76a71322cb412d81a58aed/lib/Doctrine/Query.php#L656) and secondly to the pendingFieldsList as seen in the pull request, which causes this (https://github.com/vemaeg/doctrine1/blob/502b8cce687bf57b3f76a71322cb412d81a58aed/lib/Doctrine/Query.php#L500) part to add the same name + alias to the query.

Do you know where to find any details on the issue, as the link is provided in the source is dead?

Example query: 
```php
Doctrine_Query::create()
    ->select("a.id, a.name as articleName, a.updated_at")
    ->from("Articles a")
```