### PR TITLE
Using of custom aliases causes issues with a fix for issue DC-585

### DIFF
--- a/lib/Doctrine/Query.php
+++ b/lib/Doctrine/Query.php
@@ -657,11 +657,13 @@ class Doctrine_Query extends Doctrine_Query_Abstract implements Countable
 
                 $this->_neededTables[] = $tableAlias;
 
+                // This causes the column to be added twice, if the user defines a custom alias
+                // in the select statement.
                 // Fix for http://www.doctrine-project.org/jira/browse/DC-585
                 // Add selected columns to pending fields
-                if (preg_match('/^([^\(]+)\.(\'?)(.*?)(\'?)$/', $expression, $field)) {
+                /*if (preg_match('/^([^\(]+)\.(\'?)(.*?)(\'?)$/', $expression, $field)) {
                     $this->_pendingFields[$componentAlias][$alias] = $field[3];
-                }
+                }*/
 
             } else {
                 $e = explode('.', $terms[0]);


### PR DESCRIPTION
The commented out fix, shown in this pull request, breaks the usage of custom aliases in the query, because it will be added twice to the query. First to the sqlParts-List here (https://github.com/vemaeg/doctrine1/blob/502b8cce687bf57b3f76a71322cb412d81a58aed/lib/Doctrine/Query.php#L656) and secondly to the pendingFieldsList as seen in the pull request, which causes this (https://github.com/vemaeg/doctrine1/blob/502b8cce687bf57b3f76a71322cb412d81a58aed/lib/Doctrine/Query.php#L500) part to add the same name + alias to the query.

Do you know where to find any details on the issue, as the link provided in the source is dead?

Example query: 
```php
Doctrine_Query::create()
    ->select("a.id, a.name as articleName, a.updated_at")
    ->from("Articles a")
```