### PR TITLE
Cannot declare self-referencing constant 'Doctrine_Query::STATE_CLEAN'

### DIFF
--- a/lib/Doctrine/Query/Abstract.php
+++ b/lib/Doctrine/Query/Abstract.php
@@ -97,7 +97,7 @@ abstract class Doctrine_Query_Abstract
     /**
      * @var integer $_state   The current state of this query.
      */
-    protected $_state = Doctrine_Query::STATE_CLEAN;
+    protected $_state = Doctrine_Query_Abstract::STATE_CLEAN;
 
     /**
      * @var array $_params  The parameters of this query.

--- a/lib/Doctrine/Query/Abstract.php
+++ b/lib/Doctrine/Query/Abstract.php
@@ -97,7 +97,7 @@ abstract class Doctrine_Query_Abstract
     /**
      * @var integer $_state   The current state of this query.
      */
-    protected $_state = Doctrine_Query_Abstract::STATE_CLEAN;
+    protected $_state = self::STATE_CLEAN;
 
     /**
      * @var array $_params  The parameters of this query.


### PR DESCRIPTION
We had the same issue in our fork as explained here: https://github.com/FriendsOfSymfony1/doctrine1/pull/42