### PR TITLE
Revert strict decimal comparison

### DIFF
--- a/lib/Doctrine/Validator.php
+++ b/lib/Doctrine/Validator.php
@@ -171,7 +171,7 @@ class Doctrine_Validator extends Doctrine_Locator_Injectable
             case 'float':
             case 'double':
             case 'decimal':
-                return (string) $var === (string) (float) $var;
+                return (string) $var == (string) (float) $var;
             case 'integer':
                 return (string) $var === (string)round((float) $var);
             case 'string':

--- a/tests/ValidatorTestCase.php
+++ b/tests/ValidatorTestCase.php
@@ -80,6 +80,13 @@ class Doctrine_Validator_TestCase extends Doctrine_UnitTestCase
         $this->assertFalse(Doctrine_Validator::isValidType($var, 'array'));
         $this->assertFalse(Doctrine_Validator::isValidType($var, 'object'));
 
+        $var = '123.00';
+        $this->assertTrue(Doctrine_Validator::isValidType($var, 'string'));
+        $this->assertFalse(Doctrine_Validator::isValidType($var, 'integer'));
+        $this->assertTrue(Doctrine_Validator::isValidType($var, 'float'));
+        $this->assertFalse(Doctrine_Validator::isValidType($var, 'array'));
+        $this->assertFalse(Doctrine_Validator::isValidType($var, 'object'));
+
         $var = '';
         $this->assertTrue(Doctrine_Validator::isValidType($var, 'string'));
         $this->assertFalse(Doctrine_Validator::isValidType($var, 'integer'));


### PR DESCRIPTION
Reverts BC break with decimal validation of strings that contain trailing zeroes (e.g. `'123.00'`).

Fixes #75 