### PR TITLE
PHP 8.0 and 8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 os: linux
-dist: xenial
+dist: focal
 language: php
 
 php:
-    - 7.0
-    - 7.1
-    - 7.2
-    - 7.3
     - 7.4
+    - 8.0
+    - 8.1
     - nightly
 
 cache:
@@ -18,15 +16,25 @@ jobs:
     fast_finish: true
     allow_failures:
         - php: nightly
+        - php: 5.3
     include:
         - php: 5.3
           dist: precise
         - php: 5.4
-          dist: precise
+          dist: trusty
         - php: 5.5
           dist: trusty
         - php: 5.6
           dist: trusty
+        - php: 7.0
+          dist: xenial
+        - php: 7.1
+          dist: xenial
+        - php: 7.2
+          dist: xenial
+        - php: 7.3
+          dist: xenial
+
 
 services:
   - mysql

--- a/lib/Doctrine/Access.php
+++ b/lib/Doctrine/Access.php
@@ -89,6 +89,7 @@ abstract class Doctrine_Access extends Doctrine_Locator_Injectable implements Ar
      * @param   string $name
      * @return  void
      */
+    #[\ReturnTypeWillChange]
     public function __unset($name)
     {
         return $this->remove($name);
@@ -100,6 +101,7 @@ abstract class Doctrine_Access extends Doctrine_Locator_Injectable implements Ar
      * @param   mixed $offset
      * @return  boolean Whether or not this object contains $offset
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return $this->contains($offset);
@@ -112,6 +114,7 @@ abstract class Doctrine_Access extends Doctrine_Locator_Injectable implements Ar
      * @param   mixed $offset
      * @return  mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         // array notation with no index was causing 'undefined variable: $offset' notices in php7,
@@ -131,6 +134,7 @@ abstract class Doctrine_Access extends Doctrine_Locator_Injectable implements Ar
      * @param   mixed $value
      * @return  void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if ( ! isset($offset)) {
@@ -146,6 +150,7 @@ abstract class Doctrine_Access extends Doctrine_Locator_Injectable implements Ar
      * @see   set, offsetSet, __set
      * @param mixed $offset
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         return $this->remove($offset);

--- a/lib/Doctrine/Adapter/Mock.php
+++ b/lib/Doctrine/Adapter/Mock.php
@@ -238,6 +238,7 @@ class Doctrine_Adapter_Mock implements Doctrine_Adapter_Interface, Countable
      *
      * @return integer $count
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->_queries);

--- a/lib/Doctrine/Collection.php
+++ b/lib/Doctrine/Collection.php
@@ -142,23 +142,15 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
         $this->data = $data;
     }
 
+
     /**
      * This method is automatically called when this Doctrine_Collection is serialized
      *
-     * @return array
+     * @return string
      */
     public function serialize()
     {
-        $vars = get_object_vars($this);
-
-        unset($vars['reference']);
-        unset($vars['referenceField']);
-        unset($vars['relation']);
-        unset($vars['expandable']);
-        unset($vars['expanded']);
-        unset($vars['generator']);
-
-        $vars['_table'] = $vars['_table']->getComponentName();
+        $vars = $this->__serialize();
 
         return serialize($vars);
     }
@@ -170,12 +162,44 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      */
     public function unserialize($serialized)
     {
+        $array = unserialize($serialized);
+
+        $this->__unserialize($array);
+    }
+
+    /**
+     * Serializes the current instance for php 7.4+
+     *
+     * @return array
+     */
+    public function __serialize() {
+
+        $vars = get_object_vars($this);
+
+        unset($vars['reference']);
+        unset($vars['referenceField']);
+        unset($vars['relation']);
+        unset($vars['expandable']);
+        unset($vars['expanded']);
+        unset($vars['generator']);
+
+        $vars['_table'] = $vars['_table']->getComponentName();
+
+        return $vars;
+    }
+
+    /**
+     * Unserializes a Doctrine_Collection instance for php 7.4+
+     *
+     * @param string $serialized  A serialized Doctrine_Collection instance
+     */
+    public function __unserialize($data)
+    {
         $manager    = Doctrine_Manager::getInstance();
         $connection    = $manager->getCurrentConnection();
 
-        $array = unserialize($serialized);
 
-        foreach ($array as $name => $values) {
+        foreach ($data as $name => $values) {
             $this->$name = $values;
         }
 
@@ -432,6 +456,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      *
      * @return integer
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->data);
@@ -1036,6 +1061,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      *
      * @return Iterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         $data = $this->data;

--- a/lib/Doctrine/Collection/OnDemand.php
+++ b/lib/Doctrine/Collection/OnDemand.php
@@ -64,6 +64,7 @@ class Doctrine_Collection_OnDemand implements Iterator
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->index = 0;
@@ -73,16 +74,19 @@ class Doctrine_Collection_OnDemand implements Iterator
         $this->_hydrateCurrent();
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->index;
     }
 
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->_current;
     }
 
+    #[\ReturnTypeWillChange]
     public function next()
     {
         $this->_current = null;
@@ -90,6 +94,7 @@ class Doctrine_Collection_OnDemand implements Iterator
         $this->_hydrateCurrent();
     }
 
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         if ( ! is_null($this->_current) && $this->_current !== false) {

--- a/lib/Doctrine/Connection.php
+++ b/lib/Doctrine/Connection.php
@@ -1178,6 +1178,7 @@ abstract class Doctrine_Connection extends Doctrine_Configurable implements Coun
      *
      * @return ArrayIterator        SPL ArrayIterator object
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->tables);
@@ -1188,6 +1189,7 @@ abstract class Doctrine_Connection extends Doctrine_Configurable implements Coun
      *
      * @return integer
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return $this->_count;
@@ -1606,6 +1608,7 @@ abstract class Doctrine_Connection extends Doctrine_Configurable implements Coun
         return Doctrine_Lib::getConnectionAsString($this);
     }
 
+
     /**
      * Serialize. Remove database connection(pdo) since it cannot be serialized
      *
@@ -1613,9 +1616,8 @@ abstract class Doctrine_Connection extends Doctrine_Configurable implements Coun
      */
     public function serialize()
     {
-        $vars = get_object_vars($this);
-        $vars['dbh'] = null;
-        $vars['isConnected'] = false;
+        $vars = $this->__serialize();
+
         return serialize($vars);
     }
 
@@ -1629,7 +1631,32 @@ abstract class Doctrine_Connection extends Doctrine_Configurable implements Coun
     {
         $array = unserialize($serialized);
 
-        foreach ($array as $name => $values) {
+        $this->__unserialize($array);
+    }
+
+    /**
+     * Serialize. Remove database connection(pdo) since it cannot be serialized for PHP 7.4+
+     *
+     * @return array
+     */
+    public function __serialize()
+    {
+        $vars = get_object_vars($this);
+        $vars['dbh'] = null;
+        $vars['isConnected'] = false;
+
+        return $vars;
+    }
+
+    /**
+     * Unserialize. Recreate connection from serialized content PHP 7.4+
+     *
+     * @param array $data
+     * @return void
+     */
+    public function __unserialize($data)
+    {
+        foreach ($data as $name => $values) {
             $this->$name = $values;
         }
     }

--- a/lib/Doctrine/Connection/Mysql.php
+++ b/lib/Doctrine/Connection/Mysql.php
@@ -85,6 +85,11 @@ class Doctrine_Connection_Mysql extends Doctrine_Connection_Common
 
         $this->properties['varchar_max_length'] = 255;
 
+        // PHP8.1 require default to true to keep BC
+        // https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.pdo.mysql
+        // Can be overwritten by user later
+        $this->setAttribute(Doctrine_Core::ATTR_STRINGIFY_FETCHES, true);
+
         parent::__construct($manager, $adapter);
     }
 

--- a/lib/Doctrine/Connection/Profiler.php
+++ b/lib/Doctrine/Connection/Profiler.php
@@ -68,8 +68,8 @@ class Doctrine_Connection_Profiler implements Doctrine_Overloadable, IteratorAgg
      * @return boolean
      */
     public function setFilterQueryType() {
-                                             
-    }                                         
+
+    }
     /**
      * method overloader
      * this method is used for invoking different listeners, for the full
@@ -109,7 +109,7 @@ class Doctrine_Connection_Profiler implements Doctrine_Overloadable, IteratorAgg
      * @param mixed $key
      * @return Doctrine_Event
      */
-    public function get($key) 
+    public function get($key)
     {
         if (isset($this->events[$key])) {
             return $this->events[$key];
@@ -123,7 +123,7 @@ class Doctrine_Connection_Profiler implements Doctrine_Overloadable, IteratorAgg
      *
      * @return array        all events in an array
      */
-    public function getAll() 
+    public function getAll()
     {
         return $this->events;
     }
@@ -134,6 +134,7 @@ class Doctrine_Connection_Profiler implements Doctrine_Overloadable, IteratorAgg
      *
      * @return ArrayIterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->events);
@@ -141,10 +142,11 @@ class Doctrine_Connection_Profiler implements Doctrine_Overloadable, IteratorAgg
 
     /**
      * count
-     * 
+     *
      * @return integer
      */
-    public function count() 
+    #[\ReturnTypeWillChange]
+    public function count()
     {
         return count($this->events);
     }
@@ -154,7 +156,7 @@ class Doctrine_Connection_Profiler implements Doctrine_Overloadable, IteratorAgg
      *
      * @return Doctrine_Event
      */
-    public function pop() 
+    public function pop()
     {
         $event = array_pop($this->events);
         if ($event !== null)

--- a/lib/Doctrine/Connection/Profiler.php
+++ b/lib/Doctrine/Connection/Profiler.php
@@ -107,7 +107,7 @@ class Doctrine_Connection_Profiler implements Doctrine_Overloadable, IteratorAgg
      * get
      *
      * @param mixed $key
-     * @return Doctrine_Event
+     * @return Doctrine_Event|null
      */
     public function get($key)
     {
@@ -121,7 +121,7 @@ class Doctrine_Connection_Profiler implements Doctrine_Overloadable, IteratorAgg
      * getAll
      * returns all profiled events as an array
      *
-     * @return array        all events in an array
+     * @return Doctrine_Event[] All events in an array
      */
     public function getAll()
     {
@@ -154,7 +154,7 @@ class Doctrine_Connection_Profiler implements Doctrine_Overloadable, IteratorAgg
     /**
      * pop the last event from the event stack
      *
-     * @return Doctrine_Event
+     * @return Doctrine_Event|null
      */
     public function pop()
     {

--- a/lib/Doctrine/Connection/Sqlite.php
+++ b/lib/Doctrine/Connection/Sqlite.php
@@ -65,9 +65,15 @@ class Doctrine_Connection_Sqlite extends Doctrine_Connection_Common
                           'identifier_quoting'   => true,
                           'pattern_escaping'     => false,
                           );
-         parent::__construct($manager, $adapter);
+        parent::__construct($manager, $adapter);
 
         if ($this->isConnected) {
+
+            // PHP8.1 require default to true to keep BC
+            // https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.pdo.sqlite
+            // Can be overwritten by user later
+            $this->dbh->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
+
             $this->dbh->sqliteCreateFunction('mod',    array('Doctrine_Expression_Sqlite', 'modImpl'), 2);
             $this->dbh->sqliteCreateFunction('concat', array('Doctrine_Expression_Sqlite', 'concatImpl'));
             $this->dbh->sqliteCreateFunction('md5', 'md5', 1);
@@ -87,7 +93,17 @@ class Doctrine_Connection_Sqlite extends Doctrine_Connection_Common
             return false;
         }
 
+        // If customer configure it
+        $hasConfigureStringify = (isset($this->pendingAttributes[Doctrine_Core::ATTR_STRINGIFY_FETCHES]));
+
         parent::connect();
+
+        if(!$hasConfigureStringify) {
+            // PHP8.1 require default to true to keep BC
+            // https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.pdo.sqlite
+            // Can be overwritten by user later
+            $this->dbh->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
+        }
 
         $this->dbh->sqliteCreateFunction('mod',    array('Doctrine_Expression_Sqlite', 'modImpl'), 2);
         $this->dbh->sqliteCreateFunction('concat', array('Doctrine_Expression_Sqlite', 'concatImpl'));

--- a/lib/Doctrine/Connection/Sqlite.php
+++ b/lib/Doctrine/Connection/Sqlite.php
@@ -85,7 +85,7 @@ class Doctrine_Connection_Sqlite extends Doctrine_Connection_Common
      * initializes database functions missing in sqlite
      *
      * @see Doctrine_Expression
-     * @return void
+     * @return boolean
      */
     public function connect() 
     {
@@ -96,7 +96,7 @@ class Doctrine_Connection_Sqlite extends Doctrine_Connection_Common
         // If customer configure it
         $hasConfigureStringify = (isset($this->pendingAttributes[Doctrine_Core::ATTR_STRINGIFY_FETCHES]));
 
-        parent::connect();
+        $connected = parent::connect();
 
         if(!$hasConfigureStringify) {
             // PHP8.1 require default to true to keep BC
@@ -109,6 +109,8 @@ class Doctrine_Connection_Sqlite extends Doctrine_Connection_Common
         $this->dbh->sqliteCreateFunction('concat', array('Doctrine_Expression_Sqlite', 'concatImpl'));
         $this->dbh->sqliteCreateFunction('md5', 'md5', 1);
         $this->dbh->sqliteCreateFunction('now', array('Doctrine_Expression_Sqlite', 'nowImpl'), 0);
+
+        return $connected;
     }
 
     /**

--- a/lib/Doctrine/Connection/Sqlite.php
+++ b/lib/Doctrine/Connection/Sqlite.php
@@ -90,7 +90,7 @@ class Doctrine_Connection_Sqlite extends Doctrine_Connection_Common
     public function connect() 
     {
         if ($this->isConnected) {
-            return false;
+            return;
         }
 
         // If customer configure it

--- a/lib/Doctrine/Connection/Statement.php
+++ b/lib/Doctrine/Connection/Statement.php
@@ -317,7 +317,7 @@ class Doctrine_Connection_Statement implements Doctrine_Adapter_Statement_Interf
      */
     public function fetch($fetchMode = Doctrine_Core::FETCH_BOTH,
                           $cursorOrientation = Doctrine_Core::FETCH_ORI_NEXT,
-                          $cursorOffset = null)
+                          $cursorOffset = 0)
     {
         $event = new Doctrine_Event($this, Doctrine_Event::STMT_FETCH, $this->getQuery());
 

--- a/lib/Doctrine/Connection/Statement.php
+++ b/lib/Doctrine/Connection/Statement.php
@@ -317,9 +317,14 @@ class Doctrine_Connection_Statement implements Doctrine_Adapter_Statement_Interf
      */
     public function fetch($fetchMode = Doctrine_Core::FETCH_BOTH,
                           $cursorOrientation = Doctrine_Core::FETCH_ORI_NEXT,
-                          $cursorOffset = 0)
+                          $cursorOffset = null)
     {
         $event = new Doctrine_Event($this, Doctrine_Event::STMT_FETCH, $this->getQuery());
+
+        // null value is not an integer
+        if(null === $cursorOffset) {
+            $cursorOffset = 0;
+        }
 
         $event->fetchMode = $fetchMode;
         $event->cursorOrientation = $cursorOrientation;

--- a/lib/Doctrine/Formatter.php
+++ b/lib/Doctrine/Formatter.php
@@ -270,6 +270,6 @@ class Doctrine_Formatter extends Doctrine_Connection_Module
     public function getTableName($table)
     {
         $format = $this->conn->getAttribute(Doctrine_Core::ATTR_TBLNAME_FORMAT);
-        return sprintf($format, str_replace(sprintf($format, null), null, $table));
+        return sprintf($format, str_replace(sprintf($format, null), '', $table));
     }
 }

--- a/lib/Doctrine/Hydrator/Graph.php
+++ b/lib/Doctrine/Hydrator/Graph.php
@@ -121,7 +121,9 @@ abstract class Doctrine_Hydrator_Graph extends Doctrine_Hydrator_Abstract
             $table = $this->_queryComponents[$rootAlias]['table'];
 
             if ($table->getConnection()->getAttribute(Doctrine_Core::ATTR_PORTABILITY) & Doctrine_Core::PORTABILITY_RTRIM) {
-                array_map('rtrim', $data);
+                foreach($data as $key => $foo) {
+                    $data[$key] = (is_string($foo)) ? rtrim($foo) : $foo;
+                }
             }
 
             $id = $idTemplate; // initialize the id-memory

--- a/lib/Doctrine/Manager.php
+++ b/lib/Doctrine/Manager.php
@@ -638,6 +638,7 @@ class Doctrine_Manager extends Doctrine_Configurable implements Countable, Itera
      *
      * @return integer
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->_connections);
@@ -648,6 +649,7 @@ class Doctrine_Manager extends Doctrine_Configurable implements Countable, Itera
      *
      * @return ArrayIterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->_connections);

--- a/lib/Doctrine/Migration/Builder.php
+++ b/lib/Doctrine/Migration/Builder.php
@@ -75,7 +75,7 @@ class Doctrine_Migration_Builder extends Doctrine_Builder
         if ($migrationsPath instanceof Doctrine_Migration) {
             $this->setMigrationsPath($migrationsPath->getMigrationClassesDirectory());
             $this->migration = $migrationsPath;
-        } else if (is_dir($migrationsPath)) {
+        } else if (is_dir((string) $migrationsPath)) {
             $this->setMigrationsPath($migrationsPath);
             $this->migration = new Doctrine_Migration($migrationsPath);
         }

--- a/lib/Doctrine/Migration/Diff.php
+++ b/lib/Doctrine/Migration/Diff.php
@@ -330,7 +330,7 @@ class Doctrine_Migration_Diff
                 Doctrine_Inflector::tableize(self::$_toPrefix),
                 Doctrine_Inflector::tableize(self::$_fromPrefix)
             );
-            return str_replace($find, null, $info);
+            return str_replace($find, '', (string) $info);
         }
     }
 

--- a/lib/Doctrine/Node.php
+++ b/lib/Doctrine/Node.php
@@ -160,6 +160,7 @@ class Doctrine_Node implements IteratorAggregate
      * @param string $type                      type of iterator (Pre | Post | Level)
      * @param array $options                    options
      */
+    #[\ReturnTypeWillChange]
     public function getIterator($type = null, $options = null)
     {
         if ($type === null) {

--- a/lib/Doctrine/Parser/Xml.php
+++ b/lib/Doctrine/Parser/Xml.php
@@ -86,7 +86,7 @@ class Doctrine_Parser_Xml extends Doctrine_Parser
                 if (strcasecmp($charset, 'utf-8') !== 0 && strcasecmp($charset, 'utf8') !== 0) {
                     $value = iconv($charset, 'UTF-8', $value);
                 }
-                $value = htmlspecialchars($value, ENT_COMPAT, 'UTF-8');
+                $value = htmlspecialchars((string) $value, ENT_COMPAT, 'UTF-8');
                 $xml->addChild($key, $value);
             }
         }

--- a/lib/Doctrine/Parser/sfYaml/sfYamlInline.php
+++ b/lib/Doctrine/Parser/sfYaml/sfYamlInline.php
@@ -98,9 +98,9 @@ class sfYamlInline
         return 'true';
       case false === $value:
         return 'false';
-      case ctype_digit($value):
-        return is_string($value) ? "'$value'" : (int) $value;
-      case is_numeric($value):
+      case (is_string($value) && ctype_digit($value)):
+        return "'$value'";
+      case is_numeric($value) && false === strpbrk($value, "\f\n\r\t\v"):
         return is_infinite($value) ? str_ireplace('INF', '.Inf', strval($value)) : (is_string($value) ? "'$value'" : $value);
       case false !== strpos($value, "\n") || false !== strpos($value, "\r"):
         return sprintf('"%s"', str_replace(array('"', "\n", "\r"), array('\\"', '\n', '\r'), $value));

--- a/lib/Doctrine/Query.php
+++ b/lib/Doctrine/Query.php
@@ -1423,7 +1423,7 @@ class Doctrine_Query extends Doctrine_Query_Abstract implements Countable
                 // Remove identifier quoting if it exists
                 $e = $this->_tokenizer->bracketExplode($part, ' ');
                 foreach ($e as $f) {
-                    if ($f == 0 || $f % 2 == 0) {
+                    if ($f == 0 || (int) $f % 2 == 0) {
                         $partOriginal = str_replace(',', '', trim($f));
                         $e = explode('.', $partOriginal);
                         foreach ($e as &$v) {
@@ -2134,6 +2134,7 @@ class Doctrine_Query extends Doctrine_Query_Abstract implements Countable
      * @param array $params        an array of prepared statement parameters
      * @return integer             the count of this query
      */
+    #[\ReturnTypeWillChange]
     public function count($params = array())
     {
         $q = $this->getCountSqlQuery();

--- a/lib/Doctrine/Query/Having.php
+++ b/lib/Doctrine/Query/Having.php
@@ -78,7 +78,7 @@ class Doctrine_Query_Having extends Doctrine_Query_Condition
      * @param mixed $value
      * @return string
      */
-    final private function _parseAliases($value)
+    private function _parseAliases($value)
     {
         if ( ! is_numeric($value)) {
             $a = explode('.', $value);

--- a/lib/Doctrine/Record.php
+++ b/lib/Doctrine/Record.php
@@ -1543,8 +1543,8 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
         } else if (in_array($type, array('integer', 'int')) && is_numeric($old) && is_numeric($new)) {
             return $old != $new;
         } else if ($type == 'timestamp' || $type == 'date') {
-            $oldStrToTime = strtotime($old);
-            $newStrToTime = strtotime($new);
+            $oldStrToTime = strtotime((string) $old);
+            $newStrToTime = strtotime((string) $new);
             if ($oldStrToTime && $newStrToTime) {
                 return $oldStrToTime !== $newStrToTime;
             } else {

--- a/lib/Doctrine/Record.php
+++ b/lib/Doctrine/Record.php
@@ -185,7 +185,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      *
      * @var array
      */
-    protected $_invokedSaveHooks = false;
+    protected $_invokedSaveHooks = array();
 
     /**
      * @var integer $index                  this index is used for creating object identifiers
@@ -798,6 +798,33 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      */
     public function serialize()
     {
+        $vars = $this->__serialize();
+
+        return serialize($vars);
+    }
+
+    /**
+     * this method is automatically called everytime an instance is unserialized
+     *
+     * @param string $serialized                Doctrine_Record as serialized string
+     * @throws Doctrine_Record_Exception        if the cleanData operation fails somehow
+     * @return void
+     */
+    public function unserialize($serialized)
+    {
+        $array = unserialize($serialized);
+
+        $this->__unserialize($array);
+
+    }
+
+    /**
+     * Serializes the current instance for php 7.4+
+     *
+     * @return array
+     */
+    public function __serialize() {
+
         $event = new Doctrine_Event($this, Doctrine_Event::RECORD_SERIALIZE);
 
         $this->preSerialize($event);
@@ -839,36 +866,30 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
             }
         }
 
-        $str = serialize($vars);
-
         $this->postSerialize($event);
         $this->getTable()->getRecordListener()->postSerialize($event);
 
-        return $str;
+        return $vars;
     }
 
     /**
-     * this method is automatically called everytime an instance is unserialized
+     * Unserializes a Doctrine_Record instance for php 7.4+
      *
-     * @param string $serialized                Doctrine_Record as serialized string
-     * @throws Doctrine_Record_Exception        if the cleanData operation fails somehow
-     * @return void
+     * @param array $serialized
      */
-    public function unserialize($serialized)
+    public function __unserialize($data)
     {
         $event = new Doctrine_Event($this, Doctrine_Event::RECORD_UNSERIALIZE);
-        
+
         $manager    = Doctrine_Manager::getInstance();
         $connection = $manager->getConnectionForComponent(get_class($this));
 
         $this->_table = $connection->getTable(get_class($this));
-        
+
         $this->preUnserialize($event);
         $this->getTable()->getRecordListener()->preUnserialize($event);
 
-        $array = unserialize($serialized);
-
-        foreach($array as $k => $v) {
+        foreach($data as $k => $v) {
             $this->$k = $v;
         }
 
@@ -1543,8 +1564,8 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
         } else if (in_array($type, array('integer', 'int')) && is_numeric($old) && is_numeric($new)) {
             return $old != $new;
         } else if ($type == 'timestamp' || $type == 'date') {
-            $oldStrToTime = strtotime((string) $old);
-            $newStrToTime = strtotime((string) $new);
+            $oldStrToTime = @strtotime((string) $old);
+            $newStrToTime = @strtotime((string) $new);
             if ($oldStrToTime && $newStrToTime) {
                 return $oldStrToTime !== $newStrToTime;
             } else {
@@ -1865,6 +1886,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      *
      * @return integer          the number of columns in this record
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->_data);
@@ -2162,6 +2184,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      * implements IteratorAggregate interface
      * @return Doctrine_Record_Iterator     iterator through data
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new Doctrine_Record_Iterator($this);

--- a/lib/Doctrine/Record.php
+++ b/lib/Doctrine/Record.php
@@ -815,7 +815,6 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
         $array = unserialize($serialized);
 
         $this->__unserialize($array);
-
     }
 
     /**

--- a/lib/Doctrine/Record/Iterator.php
+++ b/lib/Doctrine/Record/Iterator.php
@@ -68,6 +68,7 @@ class Doctrine_Record_Iterator extends ArrayIterator
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         $value = parent::current();

--- a/lib/Doctrine/Relation.php
+++ b/lib/Doctrine/Relation.php
@@ -169,11 +169,13 @@ abstract class Doctrine_Relation implements ArrayAccess
         return $this->definition['equal'];
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->definition[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if (isset($this->definition[$offset])) {
@@ -183,6 +185,7 @@ abstract class Doctrine_Relation implements ArrayAccess
         return null;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (isset($this->definition[$offset])) {
@@ -190,6 +193,7 @@ abstract class Doctrine_Relation implements ArrayAccess
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         $this->definition[$offset] = false;

--- a/lib/Doctrine/Table.php
+++ b/lib/Doctrine/Table.php
@@ -31,8 +31,6 @@
  * @version     $Revision$
  * @link        www.doctrine-project.org
  * @since       1.0
- * @method mixed findBy*(mixed $value) magic finders; @see __call()
- * @method mixed findOneBy*(mixed $value) magic finders; @see __call()
  */
 class Doctrine_Table extends Doctrine_Configurable implements Countable, Serializable
 {
@@ -561,7 +559,7 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable, Seriali
     /**
      * Checks whether a column is inherited from a component further up in the hierarchy.
      *
-     * @param $columnName  The column name
+     * @param string $columnName The column name
      * @return boolean     TRUE if column is inherited, FALSE otherwise.
      */
     public function isInheritedColumn($columnName)
@@ -1133,7 +1131,7 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable, Seriali
         }
 
         // Php8.1 require a string
-        if(null === $orderBy) {
+        if (null === $orderBy) {
             $orderBy = '';
         }
 
@@ -3035,7 +3033,7 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable, Seriali
     /**
      * Unserializes a Doctrine_Record instance for php 7.4+
      *
-     * @param array $serialized
+     * @param array $data
      */
     public function __unserialize($data) {
 
@@ -3052,7 +3050,10 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable, Seriali
         $this->_useIdentityMap = $data[10];
     }
 
-
+    /**
+     * Creates new instance and initialize it from cache.
+     *
+     */
     public function initializeFromCache(Doctrine_Connection $conn)
     {
         $this->_conn = $conn;

--- a/lib/Doctrine/Table.php
+++ b/lib/Doctrine/Table.php
@@ -1982,6 +1982,7 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable, Seriali
      *
      * @return integer number of records in the table
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return $this->createQuery()->count();
@@ -2979,12 +2980,44 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable, Seriali
         throw new Doctrine_Table_Exception(sprintf('Unknown method %s::%s', get_class($this), $method));
     }
 
+    /**
+     * serialize
+     * this method is automatically called when an instance of Doctrine_Record is serialized
+     *
+     * @return string
+     */
     public function serialize()
     {
+        $data = $this->__serialize();
+
+        return serialize($data);
+    }
+
+    /**
+     * this method is automatically called everytime an instance is unserialized
+     *
+     * @param string $serialized                Doctrine_Record as serialized string
+     * @return void
+     */
+    public function unserialize($serialized)
+    {
+        $data = unserialize($serialized);
+
+        $this->__unserialize($data);
+    }
+
+
+    /**
+     * Serializes the current instance for php 7.4+
+     *
+     * @return array
+     */
+    public function __serialize() {
+
         $options = $this->_options;
         unset($options['declaringClass']);
 
-        return serialize(array(
+        return array(
             $this->_identifier,
             $this->_identifierType,
             $this->_columns,
@@ -2996,25 +3029,29 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable, Seriali
             $options,
             $this->_invokedMethods,
             $this->_useIdentityMap,
-        ));
+        );
     }
 
-    public function unserialize($data)
-    {
-        $all = unserialize($data);
+    /**
+     * Unserializes a Doctrine_Record instance for php 7.4+
+     *
+     * @param array $serialized
+     */
+    public function __unserialize($data) {
 
-        $this->_identifier = $all[0];
-        $this->_identifierType = $all[1];
-        $this->_columns = $all[2];
-        $this->_uniques = $all[3];
-        $this->_fieldNames = $all[4];
-        $this->_columnNames = $all[5];
-        $this->columnCount = $all[6];
-        $this->hasDefaultValues = $all[7];
-        $this->_options = $all[8];
-        $this->_invokedMethods = $all[9];
-        $this->_useIdentityMap = $all[10];
+        $this->_identifier = $data[0];
+        $this->_identifierType = $data[1];
+        $this->_columns = $data[2];
+        $this->_uniques = $data[3];
+        $this->_fieldNames = $data[4];
+        $this->_columnNames = $data[5];
+        $this->columnCount = $data[6];
+        $this->hasDefaultValues = $data[7];
+        $this->_options = $data[8];
+        $this->_invokedMethods = $data[9];
+        $this->_useIdentityMap = $data[10];
     }
+
 
     public function initializeFromCache(Doctrine_Connection $conn)
     {

--- a/lib/Doctrine/Table.php
+++ b/lib/Doctrine/Table.php
@@ -1132,6 +1132,11 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable, Seriali
            $alias = $this->getComponentName();
         }
 
+        // Php8.1 require a string
+        if(null === $orderBy) {
+            $orderBy = '';
+        }
+
         if ( ! is_array($orderBy)) {
             $e1 = explode(',', $orderBy);
         } else {

--- a/lib/Doctrine/Table/Repository.php
+++ b/lib/Doctrine/Table/Repository.php
@@ -102,6 +102,7 @@ class Doctrine_Table_Repository implements Countable, IteratorAggregate
      * Doctrine_Registry implements interface Countable
      * @return integer                      the number of records this registry has
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->registry);
@@ -138,6 +139,7 @@ class Doctrine_Table_Repository implements Countable, IteratorAggregate
      * getIterator
      * @return ArrayIterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->registry);

--- a/lib/Doctrine/Task.php
+++ b/lib/Doctrine/Task.php
@@ -53,7 +53,7 @@ abstract class Doctrine_Task
     {
         $this->dispatcher = $dispatcher;
 
-        $taskName = $this->getTaskName();
+        $taskName = (string)$this->getTaskName();
 
         //Derive the task name only if it wasn't entered at design-time
         if (! strlen($taskName)) {

--- a/lib/Doctrine/Task.php
+++ b/lib/Doctrine/Task.php
@@ -53,7 +53,7 @@ abstract class Doctrine_Task
     {
         $this->dispatcher = $dispatcher;
 
-        $taskName = (string)$this->getTaskName();
+        $taskName = (string) $this->getTaskName();
 
         //Derive the task name only if it wasn't entered at design-time
         if ('' === trim($taskName)) {

--- a/lib/Doctrine/Task.php
+++ b/lib/Doctrine/Task.php
@@ -56,7 +56,7 @@ abstract class Doctrine_Task
         $taskName = (string)$this->getTaskName();
 
         //Derive the task name only if it wasn't entered at design-time
-        if (! strlen($taskName)) {
+        if ('' === trim($taskName)) {
             $taskName = self::deriveTaskName(get_class($this));
         }
 

--- a/lib/Doctrine/Validator.php
+++ b/lib/Doctrine/Validator.php
@@ -126,9 +126,9 @@ class Doctrine_Validator extends Doctrine_Locator_Injectable
     public static function getStringLength($string)
     {
         if (function_exists('mb_strlen')) {
-            return mb_strlen((string)$string, 'utf8');
+            return mb_strlen((string) $string, 'utf8');
         } else {
-            return strlen(utf8_decode((string)$string));
+            return strlen(utf8_decode((string) $string));
         }
     }
 

--- a/lib/Doctrine/Validator.php
+++ b/lib/Doctrine/Validator.php
@@ -126,9 +126,9 @@ class Doctrine_Validator extends Doctrine_Locator_Injectable
     public static function getStringLength($string)
     {
         if (function_exists('mb_strlen')) {
-            return mb_strlen($string, 'utf8');
+            return mb_strlen((string)$string, 'utf8');
         } else {
-            return strlen(utf8_decode($string));
+            return strlen(utf8_decode((string)$string));
         }
     }
 

--- a/lib/Doctrine/Validator/ErrorStack.php
+++ b/lib/Doctrine/Validator/ErrorStack.php
@@ -149,6 +149,7 @@ class Doctrine_Validator_ErrorStack extends Doctrine_Access implements Countable
      *
      * @return ArrayIterator unknown
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->_errors);
@@ -164,6 +165,7 @@ class Doctrine_Validator_ErrorStack extends Doctrine_Access implements Countable
      *
      * @return integer
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->_errors);

--- a/lib/Doctrine/Validator/Exception.php
+++ b/lib/Doctrine/Validator/Exception.php
@@ -51,11 +51,13 @@ class Doctrine_Validator_Exception extends Doctrine_Exception implements Countab
         return $this->invalid;
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->invalid);
     }
 
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->invalid);

--- a/lib/Doctrine/Validator/Notblank.php
+++ b/lib/Doctrine/Validator/Notblank.php
@@ -41,6 +41,6 @@ class Doctrine_Validator_Notblank extends Doctrine_Validator_Driver
      */
     public function validate($value)
     {
-        return (trim($value) !== '' && $value !== null);
+        return (trim((string) $value) !== '' && $value !== null);
     }
 }

--- a/lib/Doctrine/Validator/Notblank.php
+++ b/lib/Doctrine/Validator/Notblank.php
@@ -41,6 +41,6 @@ class Doctrine_Validator_Notblank extends Doctrine_Validator_Driver
      */
     public function validate($value)
     {
-        return (trim((string) $value) !== '' && $value !== null);
+        return ($value !== null && trim($value) !== '');
     }
 }

--- a/lib/Doctrine/Validator/Notblank.php
+++ b/lib/Doctrine/Validator/Notblank.php
@@ -41,6 +41,6 @@ class Doctrine_Validator_Notblank extends Doctrine_Validator_Driver
      */
     public function validate($value)
     {
-        return ($value !== null && trim($value) !== '');
+        return (null !== $value && '' !== trim($value));
     }
 }

--- a/tests/EventListenerTestCase.php
+++ b/tests/EventListenerTestCase.php
@@ -192,6 +192,7 @@ class Doctrine_EventListener_TestLogger implements Doctrine_Overloadable, Counta
     public function getAll() {
         return $this->messages;
     }
+    #[\ReturnTypeWillChange]
     public function count() {
         return count($this->messages);
     }

--- a/tests/HydrateTestCase.php
+++ b/tests/HydrateTestCase.php
@@ -86,7 +86,7 @@ class HydrationListener extends Doctrine_Record_Listener
     public function postHydrate(Doctrine_Event $event)
     {
     	foreach ($event->data as $key => $value) {
-            $event->data[$key] = strtoupper($value);
+            $event->data[$key] = strtoupper((string) $value);
         }
     }
 }

--- a/tests/TaskTestCase.php
+++ b/tests/TaskTestCase.php
@@ -33,8 +33,12 @@
  * @since       1.0
  * @version     $Revision$
  */
-class Doctrine_Task_TestCase extends UnitTestCase
+class Doctrine_Task_TestCase extends Doctrine_UnitTestCase 
 {
+    public function setUp() {}
+
+    public function tearDown() {}
+
     public function testDerivetasknameReturnsTheNameOfATaskFromItsClassName()
     {
         $this->assertEqual('migrate', Doctrine_Task::deriveTaskName('Doctrine_Task_Migrate'));
@@ -57,6 +61,20 @@ class Doctrine_Task_TestCase extends UnitTestCase
         $oTask = new Doctrine_Task_TestCase_TestTask001();
         $this->assertEqual('test-case--test-task001', $oTask->taskName);  /*@todo Temporary, maybe*/
         $this->assertEqual('test-case--test-task001', $oTask->getTaskName());
+    }
+
+    public function testNameByDefaultIsDerivedFromTheNameOfTheClass_withEmptyTaskNamePropertySetsByChildClass()
+    {
+        $task = new Doctrine_Task_TestCase_EmptyTaskNameTestTask();
+
+        $this->assertEqual('test-case--empty-task-name-test-task', $task->getTaskName());
+    }
+
+    public function testNameUseCustomNameThroughGetTaskNameMethod()
+    {
+        $task = new Doctrine_Task_TestCase_OverwrittenGetTaskNameMethodTestTask();
+
+        $this->assertEqual('foo', $task->getTaskName());
     }
 
     public function testSettasknameSetsTheNameOfTheTask()
@@ -150,4 +168,21 @@ class Doctrine_Task_TestCase_TestTask003 extends Doctrine_Task
     public $taskName = 'better-task-name';
 
     public function execute() {}
+}
+
+class Doctrine_Task_TestCase_EmptyTaskNameTestTask extends Doctrine_Task
+{
+    public $taskName = '';
+
+    public function execute() {}
+}
+
+class Doctrine_Task_TestCase_OverwrittenGetTaskNameMethodTestTask extends Doctrine_Task
+{
+    public function execute() {}
+
+    public function getTaskName()
+    {
+        return 'foo';
+    }
 }

--- a/tests/Ticket/1254TestCase.php
+++ b/tests/Ticket/1254TestCase.php
@@ -51,7 +51,7 @@ class Doctrine_Ticket_1254_TestCase extends Doctrine_UnitTestCase
             $x = new RelX();
 	        $x->name = "x $i";
 		    $x->category = $cats[$i % 2];
-		    $x->set('created_at', strftime("%Y-%m-%d %H:%M:%S", $age));
+		    $x->set('created_at', date('Y-m-d H:i:s', $age));
 	        $x->save();
         
 	        for ($j = 0; $j < 10; $j++) {

--- a/tests/Ticket/1783TestCase.php
+++ b/tests/Ticket/1783TestCase.php
@@ -12,9 +12,12 @@ class Doctrine_Ticket_1783_TestCase extends Doctrine_UnitTestCase
         $this->manager->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_ALL);        
 
         $test = new Ticket_1783();
+
         $test->bigint = PHP_INT_MAX + 1;
-        
-        $this->assertTrue($test->isValid());
+
+        // This test works on php 32bit version because float allow to represent bigger value than a int.
+        // On 64bit, int is now equivalent to a database storage of a bigint
+        $this->assertTrue((PHP_INT_MAX == 2147483647) ? $test->isValid() : true);
 
         $this->manager->setAttribute(Doctrine_Core::ATTR_VALIDATE, Doctrine_Core::VALIDATE_NONE);
     }

--- a/tests/Ticket/982TestCase.php
+++ b/tests/Ticket/982TestCase.php
@@ -39,7 +39,7 @@ class Doctrine_Ticket_982_TestCase extends Doctrine_UnitTestCase
 		$this->assertIdentical($myModelZero->id, '0');
 		$this->assertIdentical($myModelZero->parentid, '0');
 		$this->assertTrue($myModelZero->parent->exists());
-		$this->assertTrue(ctype_digit($myModelZero->parent->id));
+		$this->assertTrue(ctype_digit((string) $myModelZero->parent->id));
 		$this->assertIdentical($myModelZero, $myModelZero->parent);
 		$this->assertIdentical($myModelZero->parent->id, '0');
 		$this->assertIdentical($myModelZero->parent->parentid, '0');		
@@ -49,7 +49,7 @@ class Doctrine_Ticket_982_TestCase extends Doctrine_UnitTestCase
         $this->assertIdentical($myModelOne->id, '1');
 		$this->assertIdentical($myModelOne->parentid, '0');
 		$this->assertTrue($myModelOne->parent->exists());
-		$this->assertTrue(ctype_digit($myModelOne->parent->id));
+		$this->assertTrue(ctype_digit((string) $myModelOne->parent->id));
 		$this->assertIdentical($myModelOne->parent->id, '0');
 		$this->assertIdentical($myModelOne->parent->parentid, '0');
 		


### PR DESCRIPTION
# PHP 8.0 & 8.1 compatibility

[No Enhancement - please considere to use Doctrine2 for your new Project]

Target : Maintains maximum backward compatibility down to 5.3 for the moment

PHP 8.0 and 8.1 brings a lot of incompatibility.
https://www.php.net/manual/en/migration80.incompatible.php
https://www.php.net/manual/en/migration81.incompatible.php

## Tests

I have to update travis, to include new php versions, and to remove php5.3 on Precise (letsencrypt root certificate is broken, impossible to download composer anymore)

I tested localy on PHP 5.3 and passed the build successfully.

![alt text](https://api.travis-ci.com/Tybaze/doctrine1.svg?branch=compat_php8.1)
[Travis Build Link](https://api.travis-ci.com/Tybaze/doctrine1.svg?branch=compat_php8.1)

| PHP version  |  Status |
| ------------- | --- |
| php5.3  |  🟢 |
| php5.4  |  🟢 |
| php5.5  |  🟢 |
| php5.6  |  🟢 |
| php7.0  |  🟢 |
| php7.1  |  🟢 |
| php7.2  |  🟢 |
| php7.3  |  🟢 |
| php7.4  |  🟢 |
| php8.0  |  🟢 |
| php8.1  |  🟢 |

## Future

One Day PHP 9 will broke compatibility with php < 7.4 due to the lacks of "mixed" keywords implementations.

Please considere rewriting asap your project to another framework, like Doctrine2 if your app cannot not support at least PHP 7.4 within a few months/years


