### PR TITLE
PHP 8.1 > Deprecated: strtolower(): Passing null to parameter #1 ($string) of type string is deprecated

### DIFF
--- a/lib/Doctrine/Table.php
+++ b/lib/Doctrine/Table.php
@@ -1179,6 +1179,10 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable, Seriali
             return $this->_columnNames[$fieldName];
         }
 
+        if (null === $fieldName) {
+            return '';
+        }
+
         return strtolower($fieldName);
     }
 


### PR DESCRIPTION
Fixes #95 - It's still unclear why this happens, but here is a fix for it.