### PR TITLE
fix(Query): column added twice with custom aliases

### DIFF
--- a/lib/Doctrine/Hydrator/Graph.php
+++ b/lib/Doctrine/Hydrator/Graph.php
@@ -311,11 +311,17 @@ abstract class Doctrine_Hydrator_Graph extends Doctrine_Hydrator_Abstract
                 $table = $this->_queryComponents[$cache[$key]['dqlAlias']]['table'];
                 $fieldName = $table->getFieldName($last);
                 $cache[$key]['fieldName'] = $fieldName;
+
+                if (isset($this->_queryComponents[$cache[$key]['dqlAlias']]['agg_field'][$last])) {
+                    $fieldName = $this->_queryComponents[$cache[$key]['dqlAlias']]['agg_field'][$last];
+                }
+
                 if ($table->isIdentifier($fieldName)) {
                     $cache[$key]['isIdentifier'] = true;
                 } else {
                   $cache[$key]['isIdentifier'] = false;
                 }
+
                 $type = $table->getTypeOfColumn($last);
                 if ($type == 'integer' || $type == 'string') {
                     $cache[$key]['isSimpleType'] = true;

--- a/lib/Doctrine/Query.php
+++ b/lib/Doctrine/Query.php
@@ -480,7 +480,7 @@ class Doctrine_Query extends Doctrine_Query_Abstract implements Countable
         }
 
         $sql = array();
-        foreach ($fields as $fieldAlias => $fieldName) {
+        foreach ($fields as $fieldName) {
             $columnName = $table->getColumnName($fieldName);
             if (($owner = $table->getColumnOwner($columnName)) !== null &&
                     $owner !== $table->getComponentName()) {
@@ -492,17 +492,10 @@ class Doctrine_Query extends Doctrine_Query_Abstract implements Countable
                        . ' AS '
                        . $this->_conn->quoteIdentifier($tableAlias . '__' . $columnName);
             } else {
-                // Fix for http://www.doctrine-project.org/jira/browse/DC-585
-                // Take the field alias if available
-                if (isset($this->_aggregateAliasMap[$fieldAlias])) {
-                    $aliasSql = $this->_aggregateAliasMap[$fieldAlias];
-                } else {
-                    $columnName = $table->getColumnName($fieldName);
-                    $aliasSql = $this->_conn->quoteIdentifier($tableAlias . '__' . $columnName);
-                }
+                $columnName = $table->getColumnName($fieldName);
                 $sql[] = $this->_conn->quoteIdentifier($tableAlias) . '.' . $this->_conn->quoteIdentifier($columnName)
                        . ' AS '
-                       . $aliasSql;
+                       . $this->_conn->quoteIdentifier($tableAlias . '__' . $columnName);
             }
         }
 
@@ -656,13 +649,6 @@ class Doctrine_Query extends Doctrine_Query_Abstract implements Countable
                 $this->_queryComponents[$componentAlias]['agg'][$index] = $alias;
 
                 $this->_neededTables[] = $tableAlias;
-
-                // Fix for http://www.doctrine-project.org/jira/browse/DC-585
-                // Add selected columns to pending fields
-                if (preg_match('/^([^\(]+)\.(\'?)(.*?)(\'?)$/', $expression, $field)) {
-                    $this->_pendingFields[$componentAlias][$alias] = $field[3];
-                }
-
             } else {
                 $e = explode('.', $terms[0]);
 

--- a/lib/Doctrine/Query.php
+++ b/lib/Doctrine/Query.php
@@ -648,6 +648,10 @@ class Doctrine_Query extends Doctrine_Query_Abstract implements Countable
 
                 $this->_queryComponents[$componentAlias]['agg'][$index] = $alias;
 
+                if (preg_match('/^([^\(]+)\.(\'?)(.*?)(\'?)$/', $expression, $field)) {
+                    $this->_queryComponents[$componentAlias]['agg_field'][$index] = $field[3];
+                }
+
                 $this->_neededTables[] = $tableAlias;
             } else {
                 $e = explode('.', $terms[0]);

--- a/lib/Doctrine/Query/Abstract.php
+++ b/lib/Doctrine/Query/Abstract.php
@@ -206,6 +206,16 @@ abstract class Doctrine_Query_Abstract
      *
      *          map                 the name of the column / aggregate value this
      *                              component is mapped to a collection
+     *
+     *          agg_field     the field names for each aggregates
+     *                              Example:
+     *                                  DQL: COMPONENT.FIELD as ALIAS
+     *                                  SQL: TABLE.COLUMN as TABLE__0
+     *                                  $_queryComponents
+     *                                      agg:
+     *                                          0: ALIAS
+     *                                      agg_field:
+     *                                          0: FIELD
      */
     protected $_queryComponents = array();
 
@@ -1259,6 +1269,9 @@ abstract class Doctrine_Query_Abstract
             if (isset($components['agg'])) {
                 $queryComponents[$alias]['agg'] = $components['agg'];
             }
+            if (isset($components['agg_field'])) {
+                $queryComponents[$alias]['agg_field'] = $components['agg_field'];
+            }
             if (isset($components['map'])) {
                 $queryComponents[$alias]['map'] = $components['map'];
             }
@@ -1288,6 +1301,9 @@ abstract class Doctrine_Query_Abstract
             }
             if (isset($components['agg'])) {
                 $componentInfo[$alias]['agg'] = $components['agg'];
+            }
+            if (isset($components['agg_field'])) {
+                $componentInfo[$alias]['agg_field'] = $components['agg_field'];
             }
             if (isset($components['map'])) {
                 $componentInfo[$alias]['map'] = $components['map'];

--- a/tests/Ticket/585TestCase.php
+++ b/tests/Ticket/585TestCase.php
@@ -1,0 +1,70 @@
+<?php
+/*
+ *  $Id$
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+class Doctrine_Ticket_585_TestCase extends Doctrine_UnitTestCase
+{
+    private function doTestWithAllColumnsAliased($hydrateType, $expectedKeys)
+    {
+        try {
+            $query = Doctrine_Query::create()
+                ->select('u.id as aliasId, u.name as aliasName')
+                ->from('User u')
+                ->leftJoin('u.Email e')
+            ;
+
+            $results = $query->execute(array(), $hydrateType);
+
+            $expectedSql = 'SELECT e.id AS e__0, e.name AS e__1 FROM entity e LEFT JOIN email e2 ON e.email_id = e2.id WHERE (e.type = 0)';
+
+            $this->assertEqual($expectedSql, $query->getSqlQuery());
+            $this->assertEqual($expectedKeys, array_keys($results[0]));
+            $this->assertEqual(count($this->users), count($results));
+
+            $this->pass();
+        } catch (Exception $e) {
+            $this->fail($e->getMessage());
+        }
+    }
+
+    public function test_hydrateScalar_withAllColumnsAliased_thenResultsHasAllRecords()
+    {
+        $hydrateType = Doctrine_Core::HYDRATE_SCALAR;
+        $expectedKeys = array('u_aliasId', 'u_aliasName');
+
+        $this->doTestWithAllColumnsAliased($hydrateType, $expectedKeys);
+    }
+
+    public function test_hydrateArrayShallow_withAllColumnsAliased_thenResultsHasAllRecords()
+    {
+        $hydrateType = Doctrine_Core::HYDRATE_ARRAY_SHALLOW;
+        $expectedKeys = array('aliasId', 'aliasName');
+
+        $this->doTestWithAllColumnsAliased($hydrateType, $expectedKeys);
+    }
+
+    public function test_hydrateArray_withAllColumnsAliased_thenResultsHasAllRecords()
+    {
+        $hydrateType = Doctrine_Core::HYDRATE_ARRAY;
+        $expectedKeys = array('aliasId', 'aliasName');
+
+        $this->doTestWithAllColumnsAliased($hydrateType, $expectedKeys);
+    }
+}


### PR DESCRIPTION
Fixes #70

1. Test results after adding failed tests: [here](https://github.com/FriendsOfSymfony1/doctrine1/actions/runs/7595338950/job/20687788054?pr=109) :red_circle: 
2. Test results after revert DC-585 patch: [here](https://github.com/FriendsOfSymfony1/doctrine1/actions/runs/7595343184/job/20687797276?pr=109) :red_circle: 
3. Test afters provided fixes: [here](https://github.com/FriendsOfSymfony1/doctrine1/actions/runs/7595355771/job/20687822738?pr=109) :green_circle: 

Code Structure considerations
----------------------------

I would like to find a way to avoid parsing the expression as `parseClause()` already do it.

Behaviour considerations
------------------

* There is probably another bug on `Doctrine_Query::processPendingAggregates()` as the logic is similar.
* Should add a test with query cache
