### PR TITLE
replace iconv with mb_convert_encoding

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "require": {
         "php": ">=5.3",
         "ext-zlib": "*",
+        "ext-iconv": "*",
         "ext-mbstring": "*",
         "ext-pdo": "*"
     },

--- a/tests/SearchTestCase.php
+++ b/tests/SearchTestCase.php
@@ -229,7 +229,7 @@ class Doctrine_Search_TestCase extends Doctrine_UnitTestCase
         $analyzer = new Doctrine_Search_Analyzer_Utf8();
 
         // convert our test string to iso8859-15
-        $iso = iconv('UTF-8','ISO8859-15', 'un éléphant ça trompe énormément');
+        $iso = mb_convert_encoding('un éléphant ça trompe énormément', 'ISO-8859-15', 'UTF-8');
 
         $words = $analyzer->analyze($iso, 'ISO8859-15');
         $this->assertEqual($words[1], 'éléphant');


### PR DESCRIPTION
The require-dev does not include the ext-iconv requirement, but tests use it. Since there is only one place with iconv call, I replaced it with mb_convert_encoding instead. mb-string require is there anyway.