### PR TITLE
Unused local variable and fixed wrong type of the parameter

### DIFF
--- a/lib/Doctrine/Collection.php
+++ b/lib/Doctrine/Collection.php
@@ -816,7 +816,6 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      */
     public function fromArray($array, $deep = true)
     {
-        $data = array();
         foreach ($array as $rowKey => $row) {
             $this[$rowKey]->fromArray($row, $deep);
         }

--- a/lib/Doctrine/Collection.php
+++ b/lib/Doctrine/Collection.php
@@ -811,7 +811,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
     /**
      * Populate a Doctrine_Collection from an array of data
      *
-     * @param string $array
+     * @param array $array
      * @return void
      */
     public function fromArray($array, $deep = true)


### PR DESCRIPTION
Constant problem of projects with Symfony1 - wrong type `string` in phpdoc block for function Collection::fromArray()  must be `array`
