### PR TITLE
fixed CI tasks on relevant folders

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,10 +1,23 @@
 name: "Continuous Integration"
 
 on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - .github/workflows/continuous-integration.yml
+      - composer.*
+      - lib/**
+      - tests/**
+
   push:
     branches:
       - master
-  pull_request:
+    paths:
+      - .github/workflows/continuous-integration.yml
+      - composer.*
+      - lib/**
+      - tests/**
 
 env:
   fail-fast: true


### PR DESCRIPTION
During PR #126, I noticed that CI tasks are also run when nothing that is being tested changes.