### PR TITLE
Update the export command to use a PHP8-safe PDO transaction commit path

### DIFF
--- a/lib/Doctrine/Export.php
+++ b/lib/Doctrine/Export.php
@@ -1221,7 +1221,7 @@ class Doctrine_Export extends Doctrine_Connection_Module
                  }
              }
 
-             $connection->commit();
+             Doctrine_Transaction_Helper::commitIfInTransaction($connection);
          }
      }
 

--- a/lib/Doctrine/Transaction/TransactionHelper.php
+++ b/lib/Doctrine/Transaction/TransactionHelper.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ *  $Id$
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+/**
+ * Doctrine_Transaction_Helper
+ *
+ * @package     Doctrine
+ * @subpackage  Transaction
+ * @license     http://www.opensource.org/licenses/lgpl-license.php LGPL
+ * @link        www.doctrine-project.org
+ * @since       1.4
+ * @version     $Revision$
+ * @author      Kyle McGrogan <mcgrogan91@gmail.com>
+ */
+final class Doctrine_Transaction_Helper
+{
+    public static function commitIfInTransaction(Doctrine_Connection $connection): void
+    {
+        $handler = $connection->getDbh();
+
+        // Attempt to commit while no transaction is running results in exception since PHP 8 + pdo_mysql combination
+        if ($handler instanceof PDO && !$handler->inTransaction()) {
+            return;
+        }
+
+        $connection->commit();
+    }
+}


### PR DESCRIPTION
Addresses an issue reported in https://github.com/FriendsOfSymfony1/doctrine1/issues/130