### PR TITLE
PHP 8 Deprecation - Validate length on null float/decimal

### DIFF
--- a/lib/Doctrine/Validator.php
+++ b/lib/Doctrine/Validator.php
@@ -89,7 +89,7 @@ class Doctrine_Validator extends Doctrine_Locator_Injectable
      */
     public static function validateLength($value, $type, $maximumLength)
     {
-        if ($maximumLength === null ) {
+        if ($maximumLength === null || $value === null) {
             return true;
         }
         if ($type == 'timestamp' || $type == 'integer' || $type == 'enum') {

--- a/tests/ValidatorTestCase.php
+++ b/tests/ValidatorTestCase.php
@@ -123,7 +123,19 @@ class Doctrine_Validator_TestCase extends Doctrine_UnitTestCase
         $this->assertTrue(Doctrine_Validator::isValidType($var, 'object'));
     }
 
-    public function testValidate2() 
+    public function testIsValidLength()
+    {
+        // Test length is less than maximum length
+        $this->assertTrue(Doctrine_Validator::validateLength(1.2345, "decimal", 5));
+
+        // Test null value is less than maximum length
+        $this->assertTrue(Doctrine_Validator::validateLength(null, "decimal", 4));
+
+        // Test length is greater than maximum length
+        $this->assertFalse(Doctrine_Validator::validateLength(1.2345, "decimal", 4));
+    }
+
+    public function testValidate2()
     {
         $test = new ValidatorTest();
         $test->mymixed = "message";


### PR DESCRIPTION
If your model contains a nullable float/decimal, and a null value is passed into the [Doctrine_Validator::validateLength](https://github.com/iricketson/doctrine1/blob/931eef150e07796bc13919ef35f6d87f92d27487/lib/Doctrine/Validator.php#L90) static method, the validator attempts to call [abs on a null value](https://github.com/iricketson/doctrine1/blob/931eef150e07796bc13919ef35f6d87f92d27487/lib/Doctrine/Validator.php#L100), resulting in a PHP Deprecation Error:

> PHP message: PHP Deprecated:  abs(): Passing null to parameter #1 ($num) of type int|float is deprecated in /path/to/friendsofsymfony1/doctrine1/lib/Doctrine/Validator.php on line 100"

It seems that any value with a null value should pass this validator so this PR simply returns early if the value is null.