### PR TITLE
Fix return type of fromArray in Doctrine_Record

### DIFF
--- a/lib/Doctrine/Record.php
+++ b/lib/Doctrine/Record.php
@@ -1985,7 +1985,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      * @link http://www.doctrine-project.org/documentation/manual/1_1/en/working-with-models
      * @param string $array  array of data, see link for documentation
      * @param bool   $deep   whether or not to act on relations
-     * @return void
+     * @return Doctrine_Record
      */
     public function fromArray(array $array, $deep = true)
     {


### PR DESCRIPTION
Fixes the return type for the `fromArray` method, which actually [returns itself](https://github.com/iricketson/doctrine1/blob/f47a79078e7d816669a42007eb563ae28a296c9f/lib/Doctrine/Record.php#L2030) (instance of `Doctrine_Record`)