### PR TITLE
Update phpdoc on Table::findOneBy(...) to include false in @return

### DIFF
--- a/lib/Doctrine/Table.php
+++ b/lib/Doctrine/Table.php
@@ -1725,7 +1725,7 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable, Seriali
      * @param string $column            field for the WHERE clause
      * @param string|array $value       prepared statement parameter
      * @param int $hydrationMode        Doctrine_Core::HYDRATE_ARRAY or Doctrine_Core::HYDRATE_RECORD
-     * @return Doctrine_Record
+     * @return Doctrine_Record|false
      */
     public function findOneBy($fieldName, $value, $hydrationMode = null)
     {


### PR DESCRIPTION
change phpdoc on Table::findOneBy() to include 'false' 

If the fields specified do not match a row in the database, the underlying call on Doctrine_Query::fetchOne() will return false, so this method should as well.