### PR TITLE
Fix PHP deprecations on Doctrine_Record_Filter subclasses

### DIFF
--- a/lib/Doctrine/Record/Filter.php
+++ b/lib/Doctrine/Record/Filter.php
@@ -33,6 +33,9 @@
  */
 abstract class Doctrine_Record_Filter
 {
+    /**
+     * @var Doctrine_Table|null
+     */
     protected $_table;
 
     public function setTable(Doctrine_Table $table)
@@ -56,7 +59,7 @@ abstract class Doctrine_Record_Filter
      *
      * @return Doctrine_Record the given record
      *
-     * @thrown Doctrine_Exception when this way is not available
+     * @throws Doctrine_Exception when this way is not available
      */
     abstract public function filterSet(Doctrine_Record $record, $propertyOrRelation, $value);
 
@@ -67,7 +70,7 @@ abstract class Doctrine_Record_Filter
      *
      * @return mixed
      *
-     * @thrown Doctrine_Exception when this way is not available
+     * @throws Doctrine_Exception when this way is not available
      */
     abstract public function filterGet(Doctrine_Record $record, $propertyOrRelation);
 }

--- a/lib/Doctrine/Record/Filter/Compound.php
+++ b/lib/Doctrine/Record/Filter/Compound.php
@@ -56,15 +56,6 @@ class Doctrine_Record_Filter_Compound extends Doctrine_Record_Filter
         }
     }
 
-    /**
-     * Provides a way for setting property or relation value to the given record.
-     *
-     * @param string $propertyOrRelation
-     *
-     * @return Doctrine_Record the given record
-     *
-     * @thrown Doctrine_Record_UnknownPropertyException when this way is not available
-     */
     public function filterSet(Doctrine_Record $record, $propertyOrRelation, $value)
     {
         foreach ($this->_aliases as $alias) {
@@ -89,15 +80,6 @@ class Doctrine_Record_Filter_Compound extends Doctrine_Record_Filter
         throw new Doctrine_Record_UnknownPropertyException(sprintf('Unknown record property / related component "%s" on "%s"', $propertyOrRelation, get_class($record)));
     }
 
-    /**
-     * Provides a way for getting property or relation value from the given record.
-     *
-     * @param string $propertyOrRelation
-     *
-     * @return mixed
-     *
-     * @thrown Doctrine_Record_UnknownPropertyException when this way is not available
-     */
     public function filterGet(Doctrine_Record $record, $propertyOrRelation)
     {
         foreach ($this->_aliases as $alias) {

--- a/lib/Doctrine/Record/Filter/Standard.php
+++ b/lib/Doctrine/Record/Filter/Standard.php
@@ -33,21 +33,11 @@
  */
 class Doctrine_Record_Filter_Standard extends Doctrine_Record_Filter
 {
-    /**
-     * @param string $propertyOrRelation
-     *
-     * @thrown Doctrine_Record_UnknownPropertyException
-     */
     public function filterSet(Doctrine_Record $record, $propertyOrRelation, $value)
     {
         throw new Doctrine_Record_UnknownPropertyException(sprintf('Unknown record property / related component "%s" on "%s"', $propertyOrRelation, get_class($record)));
     }
 
-    /**
-     * @param string $propertyOrRelation
-     *
-     * @thrown Doctrine_Record_UnknownPropertyException
-     */
     public function filterGet(Doctrine_Record $record, $propertyOrRelation)
     {
         throw new Doctrine_Record_UnknownPropertyException(sprintf('Unknown record property / related component "%s" on "%s"', $propertyOrRelation, get_class($record)));


### PR DESCRIPTION
Fix PHP deprecations on Doctrine_Record_Filter::filterSet() and ::fil…terGet() and sub-classes