### PR TITLE
Adding support for php 8.4

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -35,6 +35,7 @@ jobs:
           - "8.1"
           - "8.2"
           - "8.3"
+          - "8.4"
 
     steps:
       - name: Checkout

--- a/lib/Doctrine/Cli.php
+++ b/lib/Doctrine/Cli.php
@@ -71,10 +71,10 @@ class Doctrine_Cli
     /**
      * __construct
      *
-     * @param array [$config=array()]
-     * @param object|null [$formatter=null] Doctrine_Cli_Formatter
+     * @param array                       $config
+     * @param Doctrine_Cli_Formatter|null $formatter
      */
-    public function __construct(array $config = array(), Doctrine_Cli_Formatter $formatter = null)
+    public function __construct(array $config = array(), ?Doctrine_Cli_Formatter $formatter = null)
     {
         $this->setConfig($config);
         $this->setFormatter($formatter ? $formatter : new Doctrine_Cli_AnsiColorFormatter());

--- a/lib/Doctrine/Collection.php
+++ b/lib/Doctrine/Collection.php
@@ -924,10 +924,10 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      * Saves all records of this collection and processes the
      * difference of the last snapshot and the current data
      *
-     * @param Doctrine_Connection $conn     optional connection parameter
+     * @param Doctrine_Connection|null $conn     optional connection parameter
      * @return Doctrine_Collection
      */
-    public function save(Doctrine_Connection $conn = null, $processDiff = true)
+    public function save(?Doctrine_Connection $conn = null, $processDiff = true)
     {
         if ($conn == null) {
             $conn = $this->_table->getConnection();
@@ -959,10 +959,10 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      * Replaces all records of this collection and processes the
      * difference of the last snapshot and the current data
      *
-     * @param Doctrine_Connection $conn     optional connection parameter
+     * @param Doctrine_Connection|null $conn     optional connection parameter
      * @return Doctrine_Collection
      */
-    public function replace(Doctrine_Connection $conn = null, $processDiff = true)
+    public function replace(?Doctrine_Connection $conn = null, $processDiff = true)
     {
         if ($conn == null) {
             $conn = $this->_table->getConnection();
@@ -995,7 +995,7 @@ class Doctrine_Collection extends Doctrine_Access implements Countable, Iterator
      *
      * @return Doctrine_Collection
      */
-    public function delete(Doctrine_Connection $conn = null, $clearColl = true)
+    public function delete(?Doctrine_Connection $conn = null, $clearColl = true)
     {
         if ($conn == null) {
             $conn = $this->_table->getConnection();

--- a/lib/Doctrine/Connection/Mssql.php
+++ b/lib/Doctrine/Connection/Mssql.php
@@ -108,12 +108,12 @@ class Doctrine_Connection_Mssql extends Doctrine_Connection_Common
      * @param mixed $limit
      * @param mixed $offset
      * @param boolean $isSubQuery
-     * @param Doctrine_Query $queryOrigin
+     * @param Doctrine_Query|null $queryOrigin
      * @link https://github.com/doctrine/dbal/blob/master/lib/Doctrine/DBAL/Platforms/MsSqlPlatform.php#L607
      * @link http://www.toosweettobesour.com/2010/09/16/doctrine-1-2-mssql-alternative-limitpaging/
      * @return string
      */
-    public function modifyLimitQuery($query, $limit = false, $offset = false, $isManip = false, $isSubQuery = false, Doctrine_Query $queryOrigin = null)
+    public function modifyLimitQuery($query, $limit = false, $offset = false, $isManip = false, $isSubQuery = false, ?Doctrine_Query $queryOrigin = null)
     {
         if ($limit === false || !($limit > 0)) {
             return $query;

--- a/lib/Doctrine/Query.php
+++ b/lib/Doctrine/Query.php
@@ -2174,9 +2174,9 @@ class Doctrine_Query extends Doctrine_Query_Abstract implements Countable
     /**
      * Copies a Doctrine_Query object.
      *
-     * @return Doctrine_Query  Copy of the Doctrine_Query instance.
+     * @return Doctrine_Query|null  Copy of the Doctrine_Query instance.
      */
-    public function copy(Doctrine_Query $query = null)
+    public function copy(?Doctrine_Query $query = null)
     {
         if ( ! $query) {
             $query = $this;

--- a/lib/Doctrine/Query/Abstract.php
+++ b/lib/Doctrine/Query/Abstract.php
@@ -292,14 +292,15 @@ abstract class Doctrine_Query_Abstract
     /**
      * Constructor.
      *
-     * @param Doctrine_Connection        $connection The connection object the query will use.
-     * @param Doctrine_Hydrator_Abstract $hydrator   The hydrator that will be used for generating result sets.
+     * @param Doctrine_Connection|null        $connection The connection object the query will use.
+     * @param Doctrine_Hydrator_Abstract|null $hydrator   The hydrator that will be used for generating result sets.
      *
      * @throws Doctrine_Connection_Exception
      */
-    public function __construct(Doctrine_Connection $connection = null,
-            Doctrine_Hydrator_Abstract $hydrator = null)
-    {
+    public function __construct(
+        ?Doctrine_Connection $connection = null,
+        ?Doctrine_Hydrator_Abstract $hydrator = null
+    ) {
         if ($connection === null) {
             $connection = Doctrine_Manager::getInstance()->getCurrentConnection();
         } else {

--- a/lib/Doctrine/Query/Part.php
+++ b/lib/Doctrine/Query/Part.php
@@ -42,7 +42,7 @@ abstract class Doctrine_Query_Part
     /**
      * @param Doctrine_Query $query         the query object associated with this parser
      */
-    public function __construct($query, Doctrine_Query_Tokenizer $tokenizer = null)
+    public function __construct($query, ?Doctrine_Query_Tokenizer $tokenizer = null)
     {
         $this->query = $query;
 

--- a/lib/Doctrine/RawSql.php
+++ b/lib/Doctrine/RawSql.php
@@ -46,10 +46,10 @@ class Doctrine_RawSql extends Doctrine_Query_Abstract
     /**
      * Constructor.
      *
-     * @param Doctrine_Connection  The connection object the query will use.
-     * @param Doctrine_Hydrator_Abstract  The hydrator that will be used for generating result sets.
+     * @param Doctrine_Connection|null        $connection The connection object the query will use.
+     * @param Doctrine_Hydrator_Abstract|null $hydrator   The hydrator that will be used for generating result sets.
      */
-    function __construct(Doctrine_Connection $connection = null, Doctrine_Hydrator_Abstract $hydrator = null) {
+    function __construct(?Doctrine_Connection $connection = null, ?Doctrine_Hydrator_Abstract $hydrator = null) {
         parent::__construct($connection, $hydrator);
 
         // Fix #1472. It's alid to disable QueryCache since there's no DQL for RawSql.

--- a/lib/Doctrine/Record.php
+++ b/lib/Doctrine/Record.php
@@ -1729,7 +1729,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      * @throws Exception                    if record is not valid and validation is active
      * @return void
      */
-    public function save(Doctrine_Connection $conn = null)
+    public function save(?Doctrine_Connection $conn = null)
     {
         if ($conn === null) {
             $conn = $this->_table->getConnection();
@@ -1746,7 +1746,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      * @param Doctrine_Connection $conn                 optional connection parameter
      * @return TRUE if the record was saved sucessfully without errors, FALSE otherwise.
      */
-    public function trySave(Doctrine_Connection $conn = null) {
+    public function trySave(?Doctrine_Connection $conn = null) {
         try {
             $this->save($conn);
             return true;
@@ -1772,7 +1772,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      * @throws Doctrine_Connection_Exception        if something fails at database level
      * @return integer                              number of rows affected
      */
-    public function replace(Doctrine_Connection $conn = null)
+    public function replace(?Doctrine_Connection $conn = null)
     {
         if ($conn === null) {
             $conn = $this->_table->getConnection();
@@ -2197,7 +2197,7 @@ abstract class Doctrine_Record extends Doctrine_Record_Abstract implements Count
      *
      * @return boolean      true if successful
      */
-    public function delete(Doctrine_Connection $conn = null)
+    public function delete(?Doctrine_Connection $conn = null)
     {
         if ($conn == null) {
             $conn = $this->_table->getConnection();

--- a/lib/Doctrine/Table.php
+++ b/lib/Doctrine/Table.php
@@ -2066,10 +2066,10 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable, Seriali
      *
      * @param string $fieldName
      * @param string $value
-     * @param Doctrine_Record $record   record to consider; if it does not exists, it is created
+     * @param Doctrine_Record|null $record   record to consider; if it does not exist, it is created
      * @return Doctrine_Validator_ErrorStack $errorStack
      */
-    public function validateField($fieldName, $value, Doctrine_Record $record = null)
+    public function validateField($fieldName, $value, ?Doctrine_Record $record = null)
     {
         if ($record instanceof Doctrine_Record) {
             $errorStack = $record->getErrorStack();
@@ -2222,7 +2222,7 @@ class Doctrine_Table extends Doctrine_Configurable implements Countable, Seriali
      *
      * @return array numeric array
      */
-    public function getColumnNames(array $fieldNames = null)
+    public function getColumnNames(?array $fieldNames = null)
     {
         if ($fieldNames === null) {
             return array_keys($this->_columns);

--- a/lib/Doctrine/Tree/Interface.php
+++ b/lib/Doctrine/Tree/Interface.php
@@ -35,9 +35,9 @@ interface Doctrine_Tree_Interface {
     /**
      * creates root node from given record or from a new record
      *
-     * @param Doctrine_Record $record                    instance of Doctrine_Record
+     * @param Doctrine_Record|null $record                    instance of Doctrine_Record
      */
-    public function createRoot(Doctrine_Record $record = null);
+    public function createRoot(?Doctrine_Record $record = null);
 
     /**
      * returns root node

--- a/lib/Doctrine/Tree/NestedSet.php
+++ b/lib/Doctrine/Tree/NestedSet.php
@@ -82,9 +82,9 @@ class Doctrine_Tree_NestedSet extends Doctrine_Tree implements Doctrine_Tree_Int
      * the records id will be assigned to the root id. You must use numeric columns for the id
      * and root id columns.
      *
-     * @param object $record        instance of Doctrine_Record
+     * @param Doctrine_Record|null $record        instance of Doctrine_Record
      */
-    public function createRoot(Doctrine_Record $record = null)
+    public function createRoot(?Doctrine_Record $record = null)
     {
         if ($this->getAttribute('hasManyRoots')) {
             if ( ! $record || ( ! $record->exists() && ! $record->getNode()->getRootValue())

--- a/tests/DoctrineTest/GroupTest.php
+++ b/tests/DoctrineTest/GroupTest.php
@@ -52,7 +52,7 @@ class GroupTest extends UnitTestCase
         }
         return true;
     }
-    public function run(DoctrineTest_Reporter $reporter = null, $filter = null)
+    public function run(?DoctrineTest_Reporter $reporter = null, $filter = null)
     {
         set_time_limit(900);
 

--- a/tests/DoctrineTest/UnitTestCase.php
+++ b/tests/DoctrineTest/UnitTestCase.php
@@ -155,7 +155,7 @@ class UnitTestCase
         self::$_passesAndFails['fails'][$class] = $class;
     }
 
-    public function run(DoctrineTest_Reporter $reporter = null, $filter = null)
+    public function run(?DoctrineTest_Reporter $reporter = null, $filter = null)
     {
         foreach (get_class_methods($this) as $method) {
             if ($this->isTestMethod($method)) {


### PR DESCRIPTION
* Fixed 8.4 deprecations for implicitly marking parameters as nullable
* Added 8.4 to the ci environment

I haven't fixed more in the docblock comments and just tried to do the minimum to reflect the changes. Still a big mess, but that's another story.